### PR TITLE
Fix for Windows

### DIFF
--- a/src/ClamAV/ClamAV.php
+++ b/src/ClamAV/ClamAV.php
@@ -85,7 +85,8 @@ abstract class ClamAV
     {
         $out = $this->sendCommand('SCAN ' .  $file);
 
-        list($file, $stats) = explode(':', $out);
+        $out = explode(':', $out);
+        $stats = end($out);
 
         $result = trim($stats);
 


### PR DESCRIPTION
On Windows the path includes the drive (e.g. 'C:\temp\to_scan.file') so the original fails as stats contains the path, not 'OK'.