### PR TITLE
Add a check for eof to avoid adding empty string to the socket data.

### DIFF
--- a/src/ClamAV/ClamAV.php
+++ b/src/ClamAV/ClamAV.php
@@ -104,7 +104,10 @@ abstract class ClamAV
         \socket_send($socket, $command, \strlen($command), 0);
 
         while (!\feof($handle)) {
-            $data = \fread($handle, $chunkSize);
+            if ("" === ($data = \fread($handle, $chunkSize))) {
+                continue;
+            }
+
             $packet = \pack(\sprintf("Na%d", $chunkSize), $chunkSize, $data);
             \socket_send($socket, $packet, $chunkSize + 4, 0);
         }


### PR DESCRIPTION
## What does this PR do?

Do not send the last empty string through the socket for files of less than 8192 bytes.
This avoid detection errors for eicar files.

## Test Plan

Tested the function with multiple eicar files.

## Related PRs and Issues

Resolve : https://github.com/appwrite/php-clamav/issues/26

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)